### PR TITLE
update README login examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ require_once __DIR__ . '/vendor/autoload.php';
 Login with credentials:
 ```php
 $dataApi = new \Lesterius\FileMakerApi\DataApi('https://test.fmconnection.com/fmi/data', 'MyDatabase');
-$dataApi->login('filemaker api user', 'filemaker api password', 'layout name');
+$dataApi->login('filemaker api user', 'filemaker api password');
 ```
 
 Login with oauth:
 ```php
 $dataApi = new \Lesterius\FileMakerApi\DataApi('https://test.fmconnection.com/fmi/data', 'MyDatabase');
-$dataApi->loginOauth('oAuthRequestId', 'oAuthIdentifier', 'layout name');
+$dataApi->loginOauth('oAuthRequestId', 'oAuthIdentifier');
 ```
 
 ### Logout


### PR DESCRIPTION
I removed the layout argument on the login examples. They're not used by the data api, and nowhere does the code use the extra argument.