### PR TITLE
Fixing script prerequest bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require": {
-        "php" : ">=7.1.0",
+        "php" : ">=7.4.0",
         "ext-curl": "*",
         "ext-mbstring": "*"
     },

--- a/src/DataApi.php
+++ b/src/DataApi.php
@@ -640,8 +640,8 @@ final class DataApi implements DataApiInterface
                 case self::SCRIPT_PREREQUEST:
                 case self::SCRIPT_PRESORT:
                     $scriptSuffix = $script['type'];
-                    $preparedScript['script' . $scriptSuffix] = $script['name'];
-                    $preparedScript['script' . $scriptSuffix . '.param'] = $script['param'];
+                    $preparedScript['script.' . $scriptSuffix] = $script['name'];
+                    $preparedScript['script.' . $scriptSuffix . '.param'] = $script['param'];
                     break;
                 case self::SCRIPT_POSTREQUEST:
                     $preparedScript['script'] = $script['name'];


### PR DESCRIPTION
Discovered an issue where submitting a SCRIPT_PREREQUEST would result in an unknown parameters error from FileMaker. There as a missing period. That has been rectified.

There is also an ancillary fix for a bug on line 197 of Response.php. Existing composer only required 7.1 or higher but that line used an option introduced after 7.1. Updating to 7.4 fixes that and theoretically avoids some issues from jumping to 8 although it's probably best to jump to 8.3 or 8.4 as even 8.0 is EOL at this point