### PR TITLE
Adds Guzzle client and API version selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ vendor
 composer.lock
 .idea
 .DS_Store
+.env
+
+package.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-FileMaker 17/18/19 Data API wrapper - myFMApiLibrary for PHP
+FileMaker 17/18/19/21/22 Data API wrapper - myFMApiLibrary for PHP
 =======================
 
 ## Team
@@ -18,7 +18,7 @@ General FileMaker document on the FMS 17 Data API is available [here](https://fm
 
 General FileMaker document on the FMS 18 Data API is available [here](https://fmhelp.filemaker.com/docs/18/en/dataapi/)
 
-General FileMaker document on the FMS 19 Data API is available [here](https://help.claris.com/en/data-api-guide/)
+General FileMaker document on the FMS 19+ Data API is available [here](https://help.claris.com/en/data-api-guide/)
 
 ## Rationale
 This fork is to bring greater out of the box compatibility to the myFMApiLibrary, vs the Lesterius upstream code. We're immensely grateful for the hard work Lesterius put in.
@@ -37,12 +37,19 @@ This fork is to bring greater out of the box compatibility to the myFMApiLibrary
 - PHP cURL extension
 - PHP mbstring extension
 
+### Library version >=3.0.0:
+
+- PHP >= 8.3
+- PHP cURL extension
+- PHP mbstring extension
+- Guzzle
+
 ## Installation
 
 The recommended way to install it is through [Composer](http://getcomposer.org).
 
 ```bash
-composer require rcconsulting/myfmapilibrary-for-php:\>=2.0.0
+composer require rcconsulting/myfmapilibrary-for-php:\>=3.0.0
 ```
 
 After installing, you need to notate that you'll use this library, and require Composer's autoloader:
@@ -92,6 +99,116 @@ $dataApi->loginOauth('oAuthRequestId', 'oAuthIdentifier');
 
 $dataApi->logout();
 ```
+
+### HTTP Client Options
+
+The library supports multiple HTTP client implementations through an abstraction layer. You can choose between cURL-based and Guzzle-based HTTP clients using either type-safe enumerations or backward-compatible strings.
+
+#### Available HTTP Clients
+
+**CurlClient (Default)**
+- Uses PHP's native cURL extension
+- Lightweight and fast
+- Default choice for backward compatibility
+
+**GuzzleClient**
+- Uses the Guzzle HTTP client library
+- Better HTTP/2 support
+- Advanced features like middleware support
+- Better error handling and debugging capabilities
+
+#### Usage Examples
+
+**Using HttpClientType Enumeration (Recommended):**
+```php
+use RCConsulting\FileMakerApi\DataApi;
+
+// Using DataApi\HttpClientType::CURL (default)
+$dataApi = new DataApi(
+    'https://test.fmconnection.com/fmi/data',
+    'MyDatabase',
+    'username',
+    'password',
+    true,                       // SSL verification
+    false,                      // Force legacy HTTP
+    false,                      // Return response object
+    HttpClient::CURL,           // HTTP client type (enum)
+    DapiVersion::V1             // Data API version (enum)
+);
+
+// Using DataApi\HttpClientType::GUZZLE
+$dataApi = new DataApi(
+    'https://test.fmconnection.com/fmi/data',
+    'MyDatabase',
+    'username',
+    'password',
+    true,                       // SSL verification
+    false,                      // Force legacy HTTP
+    false,                      // Return response object
+    HttpClient::GUZZLE,         // HTTP client type (enum)
+    DapiVersion::VLATEST        // Data API version (enum)
+);
+
+// Default behavior (uses HttpClientType::CURL)
+$dataApi = new DataApi(
+    'https://test.fmconnection.com/fmi/data',
+    'MyDatabase',
+    'username',
+    'password'
+);
+```
+
+**Using String Values (Backward Compatibility):**
+```php
+// Using string 'curl'
+$dataApi = new DataApi(
+    'https://test.fmconnection.com/fmi/data',
+    'MyDatabase',
+    'username',
+    'password',
+    true,               // SSL verification
+    false,              // Force legacy HTTP
+    false,              // Return response object
+    'curl',             // HTTP client type (string)
+    DapiVersion::V1     // Data API version (enum)
+);
+
+// Using string 'guzzle'
+$dataApi = new DataApi(
+    'https://test.fmconnection.com/fmi/data',
+    'MyDatabase',
+    'username',
+    'password',
+    true,               // SSL verification
+    false,              // Force legacy HTTP
+    false,              // Return response object
+    'guzzle',           // HTTP client type (string)
+    DapiVersion::V1     // Data API version (enum)
+);
+```
+
+**Constructor Parameters:**
+```php
+new DataApi(
+    string $apiUrl,                                     // FileMaker Data API URL
+    string $apiDatabase,                                // Database name
+    string $apiUser = null,                             // Username (optional)
+    string $apiPassword = null,                         // Password (optional)
+    bool $sslVerify = true,                             // Verify SSL certificates
+    bool $forceLegacyHTTP = false,                      // Force HTTP/1.1
+    bool $returnResponseObject = false,                 // Return full response objects
+    HttpClient|string $httpClient = HttpClient::CURL    // HTTP client (enum or string)
+    DapiVersion $dapiVersion = DapiVersion::V1          //specify Data API version (enum) currently v1, v2 or vLatest
+);
+```
+
+#### Benefits of HTTP Client Abstraction
+
+- **Flexibility**: Switch between HTTP implementations without changing your code
+- **Future-proofing**: Easy migration to new HTTP client libraries
+- **Testing**: Better mocking capabilities with Guzzle
+- **Performance**: Choose the best client for your specific needs
+- **Backward Compatibility**: Existing code continues to work unchanged
 
 ### Create record
 
@@ -171,7 +288,7 @@ $portals = [
 ];
 
 try {
-  $record = $dataApi->getRecord('layout name', $recordId, $portals, $scripts);
+  $record = $dataApi->getRecord('layout name', $recordId, $portals, $scripts, $responseLayout, $dateFormat);
 } catch(\Exception $e) {
   // handle exception
 }
@@ -194,7 +311,7 @@ $sort = [
 ];
 
 try {
-  $record = $dataApi->getRecords('layout name', $sort, $offset, $limit, $portals, $scripts);
+  $record = $dataApi->getRecords('layout name', $sort, $offset, $limit, $portals, $scripts, $responseLayout, $dateFormat);
 } catch(\Exception $e) {
   // handle exception
 }
@@ -217,7 +334,7 @@ $query = [
 ];
 
 try {
-  $results = $dataApi->findRecords('layout name', $query, $sort, $offset, $limit, $portals, $scripts, $responseLayout);
+  $results = $dataApi->findRecords('layout name', $query, $sort, $offset, $limit, $portals, $scripts, $responseLayout, $dateFormat);
 } catch(\Exception $e) {
   // handle exception
 }
@@ -316,6 +433,12 @@ if ($dataApi->validateTokenWithServer()){
 
 ```
 
+#### update object settings
+```php
+//use this if you need to explicitly use v1 or v2. The default is v1, any future versions will be added. vLatest is also supported.
+$dataApi->setDAPIVersion($dapiVersion)
+```
+
 ## ToDo:
 
-- replace all curl with [guzzle](https://github.com/guzzle/guzzle "GuzzleHTTP"), while adding [certainty](https://github.com/paragonie/certainty "Certainty") and [monolog](https://github.com/Seldaek/monolog "monolog")
+- ~~replace all curl with [guzzle](https://github.com/guzzle/guzzle "GuzzleHTTP")~~, while adding [certainty](https://github.com/paragonie/certainty "Certainty") and [monolog](https://github.com/Seldaek/monolog "monolog")

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,11 @@
            "email": "jacob.taylor@rcconsulting.com",
            "homepage": "https://rcconsulting.com"
        },
+      {
+        "name": "Jon Eisen",
+        "email": "jon.eisen@rcconsulting.com",
+        "homepage": "https://rcconsulting.com"
+      },
        {
            "name": "Steve Allen",
            "email": "steve.allen@rcconsulting.com",            
@@ -30,12 +35,13 @@
         }
     },
     "require": {
-        "php" : ">=7.4.0",
+        "php": ">=8.3.0",
         "ext-curl": "*",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "guzzlehttp/guzzle": "^7.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.6"
+        "phpunit/phpunit": "^12.3"
     },
     "config": {
       "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,12 @@
         "php": ">=8.3.0",
         "ext-curl": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^7.9"
+        "guzzlehttp/guzzle": "^7.9",
+      "ext-fileinfo": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12.3"
+        "phpunit/phpunit": "^12.3",
+        "vlucas/phpdotenv": "^5.6"
     },
     "config": {
       "sort-packages": true,

--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -2,6 +2,7 @@
 
 namespace RCConsulting\FileMakerApi;
 
+use CURLFile;
 use RCConsulting\FileMakerApi\Exception\Exception;
 
 /**
@@ -11,9 +12,9 @@ use RCConsulting\FileMakerApi\Exception\Exception;
  */
 final class CurlClient implements HttpClientInterface
 {
-    private $sslVerify = False;
-    private $baseUrl = null;
-    private $forceLegacyHTTP = False;
+    private bool $sslVerify;
+    private ?string $baseUrl;
+    private bool $forceLegacyHTTP;
 
     /**
      * CurlClient constructor
@@ -76,7 +77,7 @@ final class CurlClient implements HttpClientInterface
         }
 
         if (isset($options['file']) && !empty($options['file']) && $method === 'POST') {
-            $cURLFile = new \CURLFile($options['file']['path'], mime_content_type($options['file']['path']), $options['file']['name']);
+            $cURLFile = new CURLFile($options['file']['path'], mime_content_type($options['file']['path']), $options['file']['name']);
 
             curl_setopt($ch, CURLOPT_POSTFIELDS, ['upload' => $cURLFile]);
 
@@ -129,7 +130,7 @@ final class CurlClient implements HttpClientInterface
      *
      * @throws Exception
      */
-    private function validateResponse(Response $response)
+    private function validateResponse(Response $response): void
     {
         if ($response->getHttpCode() >= 400 && $response->getHttpCode() < 600 || $response->getHttpCode() === 100) {
             if (isset($response->getBody()['messages'][0]['message'])) {

--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -9,7 +9,7 @@ use RCConsulting\FileMakerApi\Exception\Exception;
  *
  * @package RCConsulting\DataApi
  */
-final class CurlClient
+final class CurlClient implements HttpClientInterface
 {
     private $sslVerify = False;
     private $baseUrl = null;
@@ -39,7 +39,7 @@ final class CurlClient
      * @return Response
      * @throws Exception
      */
-    public function request(string $method, string $url, array $options)
+    public function request(string $method, string $url, array $options): Response
     {
         $ch = curl_init();
         if ($ch === False) {

--- a/src/DapiVersion.php
+++ b/src/DapiVersion.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace RCConsulting\FileMakerApi;
+
+enum DapiVersion: string
+{
+    case V1 = 'v1';
+    case V2 = 'v2';
+    case VLATEST = 'vLatest';
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public static function fromString(string $value): self
+    {
+        return match (strtolower($value)) {
+            'v1' => self::V1,
+            'v2' => self::V2,
+            'vlatest' => self::VLATEST,
+            default => throw new \ValueError("Invalid API version: '$value'. Supported versions are 'v1', 'v2', and 'vLatest'.")
+        };
+    }
+}

--- a/src/DataApiInterface.php
+++ b/src/DataApiInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace RCConsulting\FileMakerApi;
+use RCConsulting\FileMakerApi\Exception\Exception;
 
 /**
  * Interface DataApiInterface
@@ -12,9 +13,9 @@ interface DataApiInterface
      * @param string $apiUsername
      * @param string $apiPassword
      *
-     * @return mixed
+     * @return $this
      */
-    public function login(string $apiUsername, string $apiPassword);
+    public function login(string $apiUsername, string $apiPassword): DataApiInterface;
 
     /**
      * @param string $oAuthRequestId
@@ -22,14 +23,14 @@ interface DataApiInterface
      *
      * @return mixed
      */
-    public function loginOauth(string $oAuthRequestId, string $oAuthIdentifier);
+    public function loginOauth(string $oAuthRequestId, string $oAuthIdentifier): DataApiInterface;
 
     /**
      *  Close the connection with FileMaker Server API
      * @return mixed
      * @throws Exception
      */
-    public function logout();
+    public function logout(): DataApiInterface;
 
     /**
      * @param string $layout
@@ -39,7 +40,7 @@ interface DataApiInterface
      *
      * @return mixed
      */
-    public function createRecord(string $layout, array $data, array $scripts = [], array $portalData = []);
+    public function createRecord(string $layout, array $data, array $scripts = [], array $portalData = []): mixed;
 
     /**
      * @param string $layout
@@ -52,7 +53,7 @@ interface DataApiInterface
      * @return mixed
      * @throws Exception
      */
-    public function editRecord(string $layout, $recordId, array $data, $lastModificationId = null, array $portalData = [], array $scripts = []);
+    public function editRecord(string $layout, $recordId, array $data, $lastModificationId = null, array $portalData = [], array $scripts = []): mixed;
 
     /**
      * Duplicate an existing record
@@ -63,7 +64,7 @@ interface DataApiInterface
      * @return mixed
      * @throws Exception
      */
-      public function duplicateRecord(string $layout, $recordId, array $scripts = []);
+      public function duplicateRecord(string $layout, $recordId, array $scripts = []): mixed;
 
       /**
        * Delete record by id
@@ -74,7 +75,7 @@ interface DataApiInterface
        *
        * @throws Exception
        */
-      public function deleteRecord(string $layout, $recordId, array $scripts = []);
+      public function deleteRecord(string $layout, $recordId, array $scripts = []): void;
 
     /**
      * Get record detail
@@ -83,25 +84,25 @@ interface DataApiInterface
      * @param       $recordId
      * @param array $portalOptions
      * @param array $scripts
-     * @param null  $responseLayout
-     *
+     * @param null $responseLayout
+     * @param int|null $dateFormat
      * @return mixed
      * @throws Exception
      */
-    public function getRecord(string $layout, $recordId, array $portalOptions = [], array $scripts = [], $responseLayout = null);
+    public function getRecord(string $layout, $recordId, array $portalOptions = [], array $scripts = [], $responseLayout = null, ?int $dateFormat = null): mixed;
 
     /**
      * @param string $layout
-     * @param null   $sort
-     * @param null   $offset
-     * @param null   $limit
+     * @param ?string   $sort
+     * @param ?int   $offset
+     * @param ?int   $limit
      * @param array  $portals
      * @param array  $scripts
-     * @param string $responseLayout
-     *
-     * @return mixed
+     * @param ?string $responseLayout
+     * @param ?int $dateFormat
+     * @return array|Response
      */
-    public function getRecords(string $layout, $sort = null, $offset = null, $limit = null, array $portals = [], array $scripts = [], string $responseLayout = null);
+    public function getRecords(string $layout, ?string $sort = null, ?int $offset = null, ?int $limit = null, array $portals = [], array $scripts = [], string $responseLayout = null, ?int $dateFormat = null): array|Response;
 
     /**
      * @param string $layout
@@ -109,50 +110,50 @@ interface DataApiInterface
      * @param string $containerFieldName
      * @param        $containerFieldRepetition
      * @param string $filepath
-     * @param string $filename
+     * @param string|null $filename
      *
      * @return mixed
      */
-    public function uploadToContainer(string $layout, $recordId, string $containerFieldName, $containerFieldRepetition, string $filepath, string $filename);
+    public function uploadToContainer(string $layout, $recordId, string $containerFieldName, $containerFieldRepetition, string $filepath, ?string $filename = null): bool;
 
     /**
      * @param string $layout
-     * @param array  $query
-     * @param null   $sort
-     * @param null   $offset
-     * @param null   $limit
-     * @param array  $portals
-     * @param array  $scripts
-     * @param string $responseLayout
+     * @param array $query
+     * @param null $sort
+     * @param null $offset
+     * @param null $limit
+     * @param array $portals
+     * @param array $scripts
+     * @param string|null $responseLayout
      *
-     * @return mixed
+     * @return array|bool|Response
      */
-    public function findRecords(string $layout, array $query, $sort = null, $offset = null, $limit = null, array $portals = [], array $scripts = [], string $responseLayout = null);
+    public function findRecords(string $layout, array $query, $sort = null, $offset = null, $limit = null, array $portals = [], array $scripts = [], string $responseLayout = null): array|bool|Response;
 
     /**
      * Execute script alone
      *
      * @param string $layout
      * @param string $scriptName
-     * @param string $scriptParam
+     * @param string|null $scriptParam
      *
-     * @return mixed
+     * @return string|true|Response
      * @throws Exception
      */
-    public function executeScript(string $layout, string $scriptName, string $scriptParam = null);
+    public function executeScript(string $layout, string $scriptName, string $scriptParam = null): string|true|Response;
 
     /**
      * @param string $layout
-     * @param array  $globalFields
+     * @param array $globalFields
      *
-     * @return mixed
+     * @return array|Response
      */
-    public function setGlobalFields(string $layout, array $globalFields);
+    public function setGlobalFields(string $layout, array $globalFields): array|Response;
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getApiToken();
+    public function getApiToken(): ?string;
 
     /**
      * @param string $token
@@ -160,55 +161,55 @@ interface DataApiInterface
      *
      * @return True|False
      */
-    public function setApiToken(string $token, $date = null);
+    public function setApiToken(string $token, $date = null): bool;
 
     /**
-     * returns API token last use date, or False if there is no last use date.
+     * returns the API token last use date, or False if there is no last use date.
      *
-     * @return string|False
+     * @return false|string|null
      */
-    public function getApiTokenDate();
+    public function getApiTokenDate(): false|string|null;
 
     /**
     * sets api token last used date. for internal library use. token lifetime is reset on each use in FM DAPI, hence this.
     *
     * @return True|False
     */
-    public function setApiTokenDate();
+    public function setApiTokenDate(): bool;
 
     /**
      * @return True|False
      */
-    public function isApiTokenExpired();
+    public function isApiTokenExpired(): bool;
 
     /**
      * @return True/False
      */
-    public function refreshToken();
+    public function refreshToken(): bool;
 
     /**
      * @return mixed
      * @throws Exception
      */
-    public function getProductInfo();
+    public function getProductInfo(): array;
 
     /**
      * @return mixed
      * @throws Exception
      */
-    public function getDatabaseNames();
+    public function getDatabaseNames(): array;
 
     /**
      * @return mixed
      * @throws Exception
      */
-    public function getLayoutNames();
+    public function getLayoutNames(): array;
 
     /**
      * @return mixed
      * @throws Exception
      */
-    public function getScriptNames();
+    public function getScriptNames(): array;
 
     /**
      * @param string $layout
@@ -217,5 +218,13 @@ interface DataApiInterface
      * @throws Exception
      * @return mixed
      */
-    public function getLayoutMetadata(string $layout, $recordId = null);
+    public function getLayoutMetadata(string $layout, $recordId = null): array;
+
+    /**
+     * set DAPIVersion separate from constructor
+     *
+     * @param DapiVersion $version
+     * @return void
+     */
+    public function setDAPIVersion(DapiVersion $version): void;
 }

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace RCConsulting\FileMakerApi;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\RequestOptions;
+use RCConsulting\FileMakerApi\Exception\Exception;
+
+/**
+ * Class GuzzleClient
+ * 
+ * Guzzle-based HTTP client implementation for the FileMaker Data API.
+ * This implementation uses the Guzzle HTTP client library instead of cURL directly.
+ *
+ * @package RCConsulting\FileMakerApi
+ */
+final class GuzzleClient implements HttpClientInterface
+{
+    private bool $sslVerify;
+    private string $baseUrl;
+    private bool $forceLegacyHTTP;
+    private Client $client;
+
+    /**
+     * GuzzleClient constructor
+     *
+     * @param string $apiUrl The base URL for the FileMaker Data API
+     * @param bool   $sslVerify Whether to verify SSL certificates
+     * @param bool   $forceLegacyHTTP Whether to force HTTP/1.1 instead of HTTP/2
+     */
+    public function __construct(string $apiUrl, bool $sslVerify, bool $forceLegacyHTTP)
+    {
+        $this->sslVerify = $sslVerify;
+        $this->baseUrl = $apiUrl;
+        $this->forceLegacyHTTP = $forceLegacyHTTP;
+
+        // Configure Guzzle client options
+        $clientOptions = [
+            'base_uri' => $this->baseUrl,
+            'verify' => $this->sslVerify,
+            'allow_redirects' => true,
+        ];
+
+        // Force HTTP/1.1 if requested
+        if ($this->forceLegacyHTTP) {
+            $clientOptions['version'] = '1.1';
+        }
+
+        $this->client = new Client($clientOptions);
+    }
+
+    /**
+     * Execute an HTTP request using Guzzle
+     *
+     * @param string $method HTTP method (GET, POST, DELETE, etc.)
+     * @param string $url The endpoint URL (relative to base URL)
+     * @param array  $options Request options including:
+     *                       - headers: array of HTTP headers
+     *                       - json: array of data to be JSON encoded
+     *                       - file: array with file upload information (path, name)
+     *                       - query_params: array of query parameters
+     *
+     * @return Response The response object containing headers, body, and status
+     * @throws Exception When the request fails or returns an error
+     */
+    public function request(string $method, string $url, array $options): Response
+    {
+        try {
+            $guzzleOptions = [];
+
+            // Set headers
+            if (isset($options['headers'])) {
+                $guzzleOptions[RequestOptions::HEADERS] = $options['headers'];
+            }
+
+            // Handle JSON payload
+            if (isset($options['json']) && !empty($options['json']) && $method !== 'GET') {
+                $guzzleOptions[RequestOptions::JSON] = $options['json'];
+            }
+
+            // Handle file upload
+            if (isset($options['file']) && !empty($options['file']) && $method === 'POST') {
+                $guzzleOptions[RequestOptions::MULTIPART] = [
+                    [
+                        'name' => 'upload',
+                        'contents' => fopen($options['file']['path'], 'r'),
+                        'filename' => $options['file']['name'],
+                    ]
+                ];
+            }
+
+            // Handle query parameters
+            if (isset($options['query_params']) && !empty($options['query_params'])) {
+                $guzzleOptions[RequestOptions::QUERY] = $options['query_params'];
+            }
+
+            // Make the request
+            $guzzleResponse = $this->client->request($method, $url, $guzzleOptions);
+
+            // Convert Guzzle response to our Response format
+            $headers = [];
+            foreach ($guzzleResponse->getHeaders() as $name => $values) {
+                $headers[$name] = implode(', ', $values);
+            }
+
+            // Add status line for compatibility with existing Response parsing
+            $headers['Status'] = sprintf(
+                'HTTP/%s %d %s',
+                $guzzleResponse->getProtocolVersion(),
+                $guzzleResponse->getStatusCode(),
+                $guzzleResponse->getReasonPhrase()
+            );
+
+            $body = (string) $guzzleResponse->getBody();
+            $response = Response::parse($this->formatHeaders($headers), $body);
+
+            $this->validateResponse($response);
+
+            return $response;
+
+        } catch (GuzzleException $e) {
+            throw new Exception($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * Format headers array into string format expected by Response::parse()
+     *
+     * @param array $headers
+     * @return string
+     */
+    private function formatHeaders(array $headers): string
+    {
+        $headerString = '';
+        foreach ($headers as $name => $value) {
+            $headerString .= $name . ': ' . $value . "\n";
+        }
+        return $headerString;
+    }
+
+    /**
+     * Validate the response and throw exceptions for error conditions
+     *
+     * @param Response $response
+     * @throws Exception
+     */
+    private function validateResponse(Response $response): void
+    {
+        if ($response->getHttpCode() >= 400 && $response->getHttpCode() < 600 || $response->getHttpCode() === 100) {
+            if (isset($response->getBody()['messages'][0]['message'])) {
+                $eMessage = is_array($response->getBody()['messages'][0]['message']) 
+                    ? implode(' - ', $response->getBody()['messages'][0]['message']) 
+                    : $response->getBody()['messages'][0]['message'];
+                $eCode = isset($response->getBody()['messages'][0]['code']) 
+                    ? $response->getBody()['messages'][0]['code'] 
+                    : $response->getHttpCode();
+
+                throw new Exception($eMessage, $eCode);
+            }
+
+            // A status code 100 with no message is OK
+            if ($response->getHttpCode() !== 100) {
+                $message = is_array($response->getBody()) || is_object($response->getBody()) 
+                    ? json_encode($response->getBody()) 
+                    : $response->getBody();
+
+                if (empty($message)) {
+                    $message = $response->getHeader('Status');
+                }
+
+                throw new Exception($message, $response->getHttpCode());
+            }
+        }
+    }
+}

--- a/src/HttpClientInterface.php
+++ b/src/HttpClientInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace RCConsulting\FileMakerApi;
+
+use RCConsulting\FileMakerApi\Exception\Exception;
+
+/**
+ * Interface HttpClientInterface
+ * 
+ * Defines the contract for HTTP client implementations used by the FileMaker Data API.
+ * This interface abstracts the HTTP transport layer to allow for different implementations
+ * such as cURL-based or Guzzle-based clients.
+ *
+ * @package RCConsulting\FileMakerApi
+ */
+interface HttpClientInterface
+{
+    /**
+     * HttpClientInterface constructor
+     *
+     * @param string $apiUrl The base URL for the FileMaker Data API
+     * @param bool   $sslVerify Whether to verify SSL certificates
+     * @param bool   $forceLegacyHTTP Whether to force HTTP/1.1 instead of HTTP/2
+     */
+    public function __construct(string $apiUrl, bool $sslVerify, bool $forceLegacyHTTP);
+
+    /**
+     * Execute an HTTP request
+     *
+     * @param string $method HTTP method (GET, POST, DELETE, etc.)
+     * @param string $url The endpoint URL (relative to base URL)
+     * @param array  $options Request options including:
+     *                       - headers: array of HTTP headers
+     *                       - json: array of data to be JSON encoded
+     *                       - file: array with file upload information (path, name)
+     *                       - query_params: array of query parameters
+     *
+     * @return Response The response object containing headers, body, and status
+     * @throws Exception When the request fails or returns an error
+     */
+    public function request(string $method, string $url, array $options): Response;
+}

--- a/src/HttpClientInterface.php
+++ b/src/HttpClientInterface.php
@@ -31,7 +31,7 @@ interface HttpClientInterface
      * @param string $url The endpoint URL (relative to base URL)
      * @param array  $options Request options including:
      *                       - headers: array of HTTP headers
-     *                       - json: array of data to be JSON encoded
+     *                       - JSON: array of data to be JSON encoded
      *                       - file: array with file upload information (path, name)
      *                       - query_params: array of query parameters
      *

--- a/src/HttpClientType.php
+++ b/src/HttpClientType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace RCConsulting\FileMakerApi;
+
+use ValueError;
+
+/**
+ * Enumeration for HTTP client types
+ *
+ * Defines the available HTTP client implementations for the FileMaker Data API.
+ * This enum provides type safety and prevents invalid client type values.
+ *
+ * @package RCConsulting\FileMakerApi
+ */
+enum HttpClientType: string
+{
+    case CURL = 'curl';
+    case GUZZLE = 'guzzle';
+
+    /**
+     * Get the string value of the enum case
+     *
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * Create enum from string value (case-insensitive)
+     *
+     * @param string $value
+     * @return HttpClientType
+     * @throws ValueError When an invalid value is provided
+     */
+    public static function fromString(string $value): HttpClientType
+    {
+        return match (strtolower($value)) {
+            'curl' => self::CURL,
+            'guzzle' => self::GUZZLE,
+            default => throw new ValueError("Invalid HTTP client type: '$value'. Supported types are 'curl' and 'guzzle'.")
+        };
+    }
+}

--- a/src/HttpClientType.php
+++ b/src/HttpClientType.php
@@ -2,44 +2,22 @@
 
 namespace RCConsulting\FileMakerApi;
 
-use ValueError;
-
-/**
- * Enumeration for HTTP client types
- *
- * Defines the available HTTP client implementations for the FileMaker Data API.
- * This enum provides type safety and prevents invalid client type values.
- *
- * @package RCConsulting\FileMakerApi
- */
 enum HttpClientType: string
 {
     case CURL = 'curl';
     case GUZZLE = 'guzzle';
 
-    /**
-     * Get the string value of the enum case
-     *
-     * @return string
-     */
     public function getValue(): string
     {
         return $this->value;
     }
 
-    /**
-     * Create enum from string value (case-insensitive)
-     *
-     * @param string $value
-     * @return HttpClientType
-     * @throws ValueError When an invalid value is provided
-     */
-    public static function fromString(string $value): HttpClientType
+    public static function fromString(string $value): self
     {
         return match (strtolower($value)) {
             'curl' => self::CURL,
             'guzzle' => self::GUZZLE,
-            default => throw new ValueError("Invalid HTTP client type: '$value'. Supported types are 'curl' and 'guzzle'.")
+            default => throw new \ValueError("Invalid HTTP client type: '$value'. Supported types are 'curl' and 'guzzle'.")
         };
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -13,23 +13,23 @@ final class Response
     /**
      * @var array
      */
-    private $headers = [];
+    private array $headers = [];
     /**
      * @var array
      */
-    private $body = [];
+    private array $body = [];
     /**
      * @var array
      */
-    private $response = [];
+    private array $response = [];
     /**
      * @var array
      */
-    private $records = [];
+    private array $records = [];
     /**
      * @var int
      */
-    private $responseCodeHTTP = null;
+    private ?int $responseCodeHTTP = null;
 
     /**
      * Response constructor.
@@ -59,18 +59,18 @@ final class Response
      * @return self
      * @throws Exception
      */
-    public static function parse(string $headers, string $body)
+    public static function parse(string $headers, string $body): self
     {
         return new self(self::parseHeaders($headers), self::parseBody($body));
     }
 
     /**
-     * @param $header
+     * @param string $header
      *
      * @return mixed
      * @throws Exception
      */
-    public function getHeader(string $header)
+    public function getHeader(string $header): mixed
     {
         if (isset($this->headers[$header])) {
             return $this->headers[$header];
@@ -82,7 +82,7 @@ final class Response
     /**
      * @return int
      */
-    public function getHttpCode()
+    public function getHttpCode(): int
     {
         return $this->responseCodeHTTP;
     }
@@ -90,7 +90,7 @@ final class Response
     /**
      * @return array
      */
-    public function getBody()
+    public function getBody(): array
     {
         return $this->body;
     }
@@ -98,7 +98,7 @@ final class Response
     /**
      * @return array
      */
-    public function getRecords()
+    public function getRecords(): array
     {
         return $this->records;
     }
@@ -106,7 +106,7 @@ final class Response
     /**
      * @return array
      */
-    public function getRawResponse()
+    public function getRawResponse(): array
     {
         return $this->response;
     }
@@ -114,7 +114,7 @@ final class Response
     /**
      * @return string
      */
-    public function getScriptResult()
+    public function getScriptResult(): string
     {
         if (isset($this->response['scriptResult']) || array_key_exists('scriptResult', $this->response)){
             return $this->response['scriptResult'];
@@ -126,7 +126,7 @@ final class Response
     /**
      * @return string
      */
-    public function getScriptError()
+    public function getScriptError(): string
     {
         if (isset($this->response['scriptError']) || array_key_exists('scriptError', $this->response)){
             return $this->response['scriptError'];
@@ -141,7 +141,7 @@ final class Response
      * @return array
      * @throws Exception
      */
-    private static function parseHeaders(string $headers)
+    private static function parseHeaders(string $headers): array
     {
         // We convert the raw header string into an array
         $headers = explode("\n", $headers);
@@ -192,7 +192,7 @@ final class Response
      * @return array
      * @throws Exception
      */
-    private static function parseBody(string $body)
+    private static function parseBody(string $body): array
     {
         return json_decode($body, true, JSON_THROW_ON_ERROR);
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -13,23 +13,23 @@ final class Response
     /**
      * @var array
      */
-    private array $headers = [];
+    private array $headers;
     /**
      * @var array
      */
-    private array $body = [];
+    private array $body;
     /**
      * @var array
      */
-    private array $response = [];
+    private array $response;
     /**
      * @var array
      */
-    private array $records = [];
+    private array $records;
     /**
-     * @var int
+     * @var ?int
      */
-    private ?int $responseCodeHTTP = null;
+    private ?int $responseCodeHTTP;
 
     /**
      * Response constructor.
@@ -44,13 +44,18 @@ final class Response
         $this->headers = $headers;
         $this->body = $body;
         $this->response = $this->body['response'];
+
         //checks to see if data even exists in this response type, logins do not, for example
         if (isset($this->response['data']) || array_key_exists('data', $this->response)) {
             $this->records = $this->response['data'];
+        } else {
+            $this->records = []; // Initialize as empty array when no data exists
         }
+
         // parses "HTTP/1.1 200 OK" and returns the 200
         $this->responseCodeHTTP = (int)explode(" ", $this->getHeader("Status"))[1];
     }
+
 
     /**
      * @param string $headers
@@ -153,7 +158,7 @@ final class Response
             }, $exploded);
         }, $headers);
 
-        // We remove empty lines in array
+        // We remove empty lines in the array
         $headers = array_filter($headers, function ($value) {
             return (is_array($value) ? $value[0] : $value) !== '';
         });

--- a/tests/UnitTests.php
+++ b/tests/UnitTests.php
@@ -1,0 +1,483 @@
+<?php
+
+namespace RCConsulting\FileMakerApi;
+
+use PHPUnit\Framework\TestCase;
+use RCConsulting\FileMakerApi\Exception\Exception;
+use ReflectionClass;
+use Dotenv\Dotenv;
+
+final class UnitTests extends TestCase
+{
+    private static ?DataApi $dataApi = null;
+    private static bool $envLoaded = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (file_exists(__DIR__ . '/../.env')) {
+            $dotenv = Dotenv::createImmutable(__DIR__ . '/..');
+            $dotenv->load();
+            self::$envLoaded = true;
+        }
+    }
+
+    private function hasRequiredEnvVars(): bool
+    {
+        return !empty($_ENV['FM_SERVER_URL']) &&
+            !empty($_ENV['FM_DATABASE']) &&
+            !empty($_ENV['FM_USERNAME']) &&
+            !empty($_ENV['FM_PASSWORD']);
+    }
+
+    private function getDataApi(): DataApi
+    {
+        if (self::$dataApi === null) {
+            self::$dataApi = new DataApi($_ENV['FM_SERVER_URL'], $_ENV['FM_DATABASE']);
+        }
+        return self::$dataApi;
+    }
+
+    // HttpClientType enum tests
+    public function testHttpClientEnumValues(): void
+    {
+        $this->assertEquals('curl', HttpClientType::CURL->getValue());
+        $this->assertEquals('guzzle', HttpClientType::GUZZLE->getValue());
+        $this->assertEquals('curl', HttpClientType::CURL->value);
+        $this->assertEquals('guzzle', HttpClientType::GUZZLE->value);
+    }
+
+    public function testHttpClientFromString(): void
+    {
+        $this->assertEquals(HttpClientType::CURL, HttpClientType::fromString('curl'));
+        $this->assertEquals(HttpClientType::GUZZLE, HttpClientType::fromString('guzzle'));
+        $this->assertEquals(HttpClientType::CURL, HttpClientType::fromString('CURL'));
+        $this->assertEquals(HttpClientType::GUZZLE, HttpClientType::fromString('GUZZLE'));
+        $this->assertEquals(HttpClientType::CURL, HttpClientType::fromString('CuRl'));
+        $this->assertEquals(HttpClientType::GUZZLE, HttpClientType::fromString('GuZzLe'));
+    }
+
+    public function testHttpClientFromInvalidString(): void
+    {
+        $this->expectException(\ValueError::class);
+        HttpClientType::fromString('invalid');
+    }
+
+    public function testHttpClientFromEmptyString(): void
+    {
+        $this->expectException(\ValueError::class);
+        HttpClientType::fromString('');
+    }
+
+    public function testHttpClientFromNumericString(): void
+    {
+        $this->expectException(\ValueError::class);
+        HttpClientType::fromString('123');
+    }
+
+    // Constructor tests (without login)
+    public function testConstructorWithDefaults(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $this->assertInstanceOf(DataApi::class, $dataApi);
+    }
+
+    public function testConstructorWithSpecialCharactersInDatabase(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'Test DB With Spaces');
+        $this->assertInstanceOf(DataApi::class, $dataApi);
+    }
+
+    public function testConstructorWithInvalidHttpClient(): void
+    {
+        $this->expectException(\ValueError::class);
+        new DataApi('https://test.com/fmi/data', 'TestDB', null, null, true, false, false, 'invalid');
+    }
+
+    // Token management edge cases
+    public function testTokenManagementWithNullToken(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $this->assertNull($dataApi->getApiToken());
+        $this->assertFalse($dataApi->getApiTokenDate());
+        $this->assertTrue($dataApi->isApiTokenExpired());
+    }
+
+    public function testTokenManagementWithEmptyToken(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $this->assertFalse($dataApi->setApiToken(''));
+    }
+
+    public function testTokenManagementWithCustomDate(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $customDate = time() - 300; // 5 minutes ago
+        $dataApi->setApiToken('test-token', $customDate);
+        $this->assertEquals($customDate, $dataApi->getApiTokenDate());
+        $this->assertFalse($dataApi->isApiTokenExpired());
+    }
+
+    public function testTokenExpirationBoundary(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+
+        // Exactly at expiration boundary (14 minutes)
+        $dataApi->setApiToken('test-token', time() - (14 * 60));
+        $this->assertFalse($dataApi->isApiTokenExpired());
+
+        // Just over expiration boundary
+        $dataApi->setApiToken('test-token', time() - (14 * 60 + 1));
+        $this->assertTrue($dataApi->isApiTokenExpired());
+    }
+
+    // URL preparation edge cases
+    public function testPrepareURLpartWithSpecialCharacters(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('prepareURLpart');
+        $method->setAccessible(true);
+
+        $this->assertEquals('test%20value', $method->invoke($dataApi, 'test value'));
+        $this->assertEquals('test%2Bvalue', $method->invoke($dataApi, 'test+value'));
+        $this->assertEquals('test%26value', $method->invoke($dataApi, 'test&value'));
+        $this->assertEquals('test%2Fvalue', $method->invoke($dataApi, 'test/value'));
+        $this->assertEquals('test%3Fvalue', $method->invoke($dataApi, 'test?value'));
+        $this->assertEquals('test%23value', $method->invoke($dataApi, 'test#value'));
+    }
+
+    public function testPrepareURLpartWithEmptyString(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('prepareURLpart');
+        $method->setAccessible(true);
+
+        $this->assertEquals('', $method->invoke($dataApi, ''));
+    }
+
+    public function testPrepareURLpartWithWhitespace(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('prepareURLpart');
+        $method->setAccessible(true);
+
+        $this->assertEquals('', $method->invoke($dataApi, '   '));
+        $this->assertEquals('test', $method->invoke($dataApi, '  test  '));
+    }
+
+    // Script options edge cases
+    public function testPrepareScriptOptionsEmpty(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('prepareScriptOptions');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($dataApi, []);
+        $this->assertEquals([], $result);
+    }
+
+    public function testPrepareScriptOptionsWithEmptyParam(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('prepareScriptOptions');
+        $method->setAccessible(true);
+
+        $scripts = [
+            [
+                'name' => 'TestScript',
+                'param' => '',
+                'type' => DataApi::SCRIPT_POSTREQUEST
+            ]
+        ];
+
+        $result = $method->invoke($dataApi, $scripts);
+        $this->assertEquals('TestScript', $result['script']);
+        $this->assertArrayNotHasKey('script.param', $result);
+    }
+
+    // Portal options edge cases
+    public function testPreparePortalsOptionsEmpty(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('preparePortalsOptions');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($dataApi, []);
+        $this->assertEquals([], $result);
+    }
+
+    // Date format edge cases
+    public function testPrepareDateFormatAllValues(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('prepareDateFormat');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($dataApi, DataApi::DATE_DEFAULT);
+        $this->assertEquals(0, $result['dateformats']);
+
+        $result = $method->invoke($dataApi, DataApi::DATE_FILELOCALE);
+        $this->assertEquals(1, $result['dateformats']);
+
+        $result = $method->invoke($dataApi, DataApi::DATE_ISO8601);
+        $this->assertEquals(2, $result['dateformats']);
+
+        // Test invalid value defaults to 0
+        $result = $method->invoke($dataApi, 999);
+        $this->assertEquals(0, $result['dateformats']);
+    }
+
+    // Credential storage edge cases
+    public function testStoreCredentialsWithEmptyValues(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('storeCredentials');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($dataApi, '', 'password'));
+        $this->assertFalse($method->invoke($dataApi, 'user', ''));
+        $this->assertFalse($method->invoke($dataApi, '', ''));
+    }
+
+    public function testStoreOAuthWithEmptyValues(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('storeOAuth');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($dataApi, '', 'identifier'));
+        $this->assertFalse($method->invoke($dataApi, 'request-id', ''));
+        $this->assertFalse($method->invoke($dataApi, '', ''));
+    }
+
+    // Constants validation
+    public function testAllConstants(): void
+    {
+        // FileMaker constants
+        $this->assertEquals(401, DataApi::FILEMAKER_NO_RECORDS);
+        $this->assertEquals(952, DataApi::FILEMAKER_API_TOKEN_EXPIRED);
+
+        // Script constants
+        $this->assertEquals('prerequest', DataApi::SCRIPT_PREREQUEST);
+        $this->assertEquals('presort', DataApi::SCRIPT_PRESORT);
+        $this->assertEquals('postrequest', DataApi::SCRIPT_POSTREQUEST);
+
+        // Date constants
+        $this->assertEquals(0, DataApi::DATE_DEFAULT);
+        $this->assertEquals(1, DataApi::DATE_FILELOCALE);
+        $this->assertEquals(2, DataApi::DATE_ISO8601);
+    }
+
+    // HTTP client creation edge cases
+    public function testCreateHttpClientWithAllCombinations(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('createHttpClient');
+        $method->setAccessible(true);
+
+        // Test all SSL and HTTP combinations
+        $combinations = [
+            [HttpClientType::CURL, true, true],
+            [HttpClientType::CURL, true, false],
+            [HttpClientType::CURL, false, true],
+            [HttpClientType::CURL, false, false],
+            [HttpClientType::GUZZLE, true, true],
+            [HttpClientType::GUZZLE, true, false],
+            [HttpClientType::GUZZLE, false, true],
+            [HttpClientType::GUZZLE, false, false],
+        ];
+
+        foreach ($combinations as [$client, $ssl, $legacy]) {
+            $result = $method->invoke($dataApi, $client, 'https://test.com', $ssl, $legacy);
+            $this->assertInstanceOf(HttpClientInterface::class, $result);
+        }
+    }
+
+    public function testCreateHttpClientWithCaseInsensitiveStrings(): void
+    {
+        $dataApi = new DataApi('https://test.com/fmi/data', 'TestDB');
+        $reflection = new ReflectionClass($dataApi);
+        $method = $reflection->getMethod('createHttpClient');
+        $method->setAccessible(true);
+
+        $strings = ['curl', 'CURL', 'Curl', 'cURL', 'guzzle', 'GUZZLE', 'Guzzle', 'GuZzLe'];
+
+        foreach ($strings as $string) {
+            $result = $method->invoke($dataApi, $string, 'https://test.com', true, false);
+            $this->assertInstanceOf(HttpClientInterface::class, $result);
+        }
+    }
+
+    // INTEGRATION TESTS - These require .env file with FileMaker credentials
+
+    public function testIntegrationLogin(): void
+    {
+        if (!self::$envLoaded || !$this->hasRequiredEnvVars()) {
+            $this->markTestSkipped('Environment variables not configured');
+        }
+
+        $dataApi = $this->getDataApi();
+        $result = $dataApi->login($_ENV['FM_USERNAME'], $_ENV['FM_PASSWORD']);
+
+        $this->assertInstanceOf(DataApi::class, $result);
+        $this->assertNotNull($dataApi->getApiToken());
+    }
+
+    public function testIntegrationLoginWithCurl(): void
+    {
+        if (!self::$envLoaded || !$this->hasRequiredEnvVars()) {
+            $this->markTestSkipped('Environment variables not configured');
+        }
+
+        $dataApi = new DataApi($_ENV['FM_SERVER_URL'], $_ENV['FM_DATABASE'], null, null, true, false, false, HttpClientType::CURL);
+        $result = $dataApi->login($_ENV['FM_USERNAME'], $_ENV['FM_PASSWORD']);
+
+        $this->assertInstanceOf(DataApi::class, $result);
+        $this->assertNotNull($dataApi->getApiToken());
+    }
+
+    public function testIntegrationLoginWithGuzzle(): void
+    {
+        if (!self::$envLoaded || !$this->hasRequiredEnvVars()) {
+            $this->markTestSkipped('Environment variables not configured');
+        }
+
+        $dataApi = new DataApi($_ENV['FM_SERVER_URL'], $_ENV['FM_DATABASE'], null, null, true, false, false, HttpClientType::GUZZLE);
+        $result = $dataApi->login($_ENV['FM_USERNAME'], $_ENV['FM_PASSWORD']);
+
+        $this->assertInstanceOf(DataApi::class, $result);
+        $this->assertNotNull($dataApi->getApiToken());
+    }
+
+    public function testIntegrationGetRecords(): void
+    {
+        if (!self::$envLoaded || !$this->hasRequiredEnvVars() || empty($_ENV['FM_LAYOUT'])) {
+            $this->markTestSkipped('Environment variables not configured');
+        }
+
+        $dataApi = $this->getDataApi();
+        $dataApi->login($_ENV['FM_USERNAME'], $_ENV['FM_PASSWORD']);
+
+        $records = $dataApi->getRecords($_ENV['FM_LAYOUT'], null, null, 1);
+        $this->assertIsArray($records);
+    }
+
+    public function testIntegrationCreateAndDeleteRecord(): void
+    {
+        if (!self::$envLoaded || !$this->hasRequiredEnvVars() || empty($_ENV['FM_LAYOUT'])) {
+            $this->markTestSkipped('Environment variables not configured');
+        }
+
+        // Create DataApi with returnResponseObject enabled for debugging
+        $dataApi = new DataApi($_ENV['FM_SERVER_URL'], $_ENV['FM_DATABASE'], null, null, true, false, true);
+        $dataApi->login($_ENV['FM_USERNAME'], $_ENV['FM_PASSWORD']);
+
+        // Create test record with minimal data
+        $testData = ['Account' => 'TEST_' . time()];
+        $response = $dataApi->createRecord($_ENV['FM_LAYOUT'], $testData);
+
+        // Debug: Dump the raw response
+        echo "\n=== RAW RESPONSE DEBUG ===\n";
+        echo "Response object type: " . get_class($response) . "\n";
+        echo "Raw response body: " . json_encode($response->getBody(), JSON_PRETTY_PRINT) . "\n";
+        echo "Raw response data: " . json_encode($response->getRawResponse(), JSON_PRETTY_PRINT) . "\n";
+        echo "Records: " . json_encode($response->getRecords(), JSON_PRETTY_PRINT) . "\n";
+        echo "Record ID: " . get_debug_type($response->getRawResponse()['recordId'] ) . "\n";
+        echo "=== END DEBUG ===\n";
+
+        $this->assertInstanceOf(Response::class, $response);
+
+        // Extract record ID from response
+        $recordId = $response->getBody()['response']['recordId'];
+        $this->assertIsString($recordId);
+        $this->assertNotEmpty($recordId);
+
+        // Clean up - delete the record
+        $dataApi->deleteRecord($_ENV['FM_LAYOUT'], $recordId);
+        $this->assertTrue(true); // No exception thrown
+    }
+
+
+    public function testIntegrationLogout(): void
+    {
+        if (!self::$envLoaded || !$this->hasRequiredEnvVars()) {
+            $this->markTestSkipped('Environment variables not configured');
+        }
+
+        $dataApi = new DataApi($_ENV['FM_SERVER_URL'], $_ENV['FM_DATABASE']);
+        $dataApi->login($_ENV['FM_USERNAME'], $_ENV['FM_PASSWORD']);
+
+        $result = $dataApi->logout();
+        $this->assertInstanceOf(DataApi::class, $result);
+        $this->assertNull($dataApi->getApiToken());
+    }
+
+    public function testIntegrationTokenRefresh(): void
+    {
+        if (!self::$envLoaded || !$this->hasRequiredEnvVars()) {
+            $this->markTestSkipped('Environment variables not configured');
+        }
+
+        $dataApi = new DataApi($_ENV['FM_SERVER_URL'], $_ENV['FM_DATABASE']);
+        $dataApi->login($_ENV['FM_USERNAME'], $_ENV['FM_PASSWORD']);
+
+        $originalToken = $dataApi->getApiToken();
+        $this->assertTrue($dataApi->refreshToken());
+
+        // Token should be refreshed (might be same or different)
+        $this->assertNotNull($dataApi->getApiToken());
+    }
+
+    public function testIntegrationValidateTokenWithServer(): void
+    {
+        if (!self::$envLoaded || !$this->hasRequiredEnvVars()) {
+            $this->markTestSkipped('Environment variables not configured');
+        }
+
+        $dataApi = new DataApi($_ENV['FM_SERVER_URL'], $_ENV['FM_DATABASE']);
+        $dataApi->login($_ENV['FM_USERNAME'], $_ENV['FM_PASSWORD']);
+
+        // Use reflection to access the protected ClientRequest property
+        $reflection = new ReflectionClass($dataApi);
+        $clientProperty = $reflection->getProperty('ClientRequest');
+        $clientProperty->setAccessible(true);
+        $client = $clientProperty->getValue($dataApi);
+
+        $headersMethod = $reflection->getMethod('getDefaultHeaders');
+        $headersMethod->setAccessible(true);
+        $headers = $headersMethod->invoke($dataApi);
+
+        // Make the request directly to debug
+        $response = $client->request(
+            'GET',
+            "/vLatest/validateSession",
+            [
+                'headers' => $headers
+            ]
+        );
+
+        echo "\n=== VALIDATE TOKEN DEBUG ===\n";
+        echo "Response body: " . json_encode($response->getBody(), JSON_PRETTY_PRINT) . "\n";
+        if (isset($response->getBody()['messages'])) {
+            echo "Messages array: " . json_encode($response->getBody()['messages'], JSON_PRETTY_PRINT) . "\n";
+            echo "First message code: " . var_export($response->getBody()['messages'][0]['code'], true) . "\n";
+            echo "Code type: " . gettype($response->getBody()['messages'][0]['code']) . "\n";
+            echo "Strict comparison (=== 0): " . var_export($response->getBody()['messages'][0]['code'] === 0, true) . "\n";
+            echo "Loose comparison (== 0): " . var_export($response->getBody()['messages'][0]['code'] == 0, true) . "\n";
+        }
+        echo "=== END DEBUG ===\n";
+
+        $this->assertTrue($dataApi->validateTokenWithServer());
+    }
+
+
+}


### PR DESCRIPTION
Possible v3.0 candidate: Improves the library with the following changes:

- Introduces Guzzle as an alternative HTTP client, enhancing flexibility and HTTP/2 support.
- Adds the ability to specify the FileMaker Data API version to use (v1, v2, vLatest).
- Updates dependencies and PHP version requirement to 8.3.
- Implements extended unit testing for improved code reliability.